### PR TITLE
DEV-56-configure-remote-source

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -1,10 +1,12 @@
 name: Generate
+
 permissions:
   checks: write
   contents: write
   pull-requests: write
   statuses: write
-"on":
+
+on:
   workflow_dispatch:
     inputs:
       force:
@@ -14,8 +16,6 @@ permissions:
       set_version:
         description: optionally set a specific SDK version
         type: string
-  # schedule:
-  #   - cron: 0 0 * * *
 jobs:
   generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     PushPress-OAS:
         inputs:
-            - location: /Users/iankaplan/projects/PushPress-Services/core-api-fastify/openapi.platform.gen.yaml
+            - location: https://api.pushpressdev.com/platform/docs/json
         overlays:
             - location: .speakeasy/speakeasy-modifications-overlay.yaml
         registry:


### PR DESCRIPTION
### TL;DR

Updated SDK generation workflow and input source for OpenAPI specification.

### What changed?

- Modified `.github/workflows/sdk_generation.yaml`:
  - Improved formatting and structure
  - Removed commented-out schedule section

- Updated `.speakeasy/workflow.yaml`:
  - Changed the input location for PushPress-OAS from a local file path to a remote URL

### How to test?

1. Trigger the SDK generation workflow manually
2. Verify that the workflow runs successfully
3. Check that the generated SDK is based on the OpenAPI specification from the new URL

### Why make this change?

- The workflow file changes improve readability and remove unused code
- Updating the input source to a remote URL ensures that the SDK is generated from the most up-to-date API specification, making it easier to maintain and reducing the risk of using outdated local files