### PR TITLE
chore!: bump SDK to 1.0.0

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -10,15 +10,15 @@ generation:
   useClassNamesForArrayFields: true
   fixes:
     nameResolutionDec2023: true
+    nameResolutionFeb2025: false
     parameterOrderingFeb2024: true
     requestResponseComponentNamesFeb2024: true
-    nameResolutionFeb2025: false
     securityFeb2025: false
   auth:
     oAuth2ClientCredentialsEnabled: false
     oAuth2PasswordEnabled: false
 typescript:
-  version: 0.40.0
+  version: 1.0.0
   additionalDependencies:
     dependencies: {}
     devDependencies: {}


### PR DESCRIPTION
By bumping to 1.0.0, we'll be able to take advantage of Speakeasy's [automatic semver algorithm](https://www.speakeasy.com/docs/manage/versioning#major-version-bumps).